### PR TITLE
fix: #422 prevent export hook setting JAVA_HOME when system

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash
@@ -1,8 +1,21 @@
 #export
 
+_jenv_export_hook() {
+  if ! type -t jenv &>/dev/null
+  then
+    return
+  fi
 
- _jenv_export_hook() {
-  export JAVA_HOME=$(jenv javahome)
+  export JENV_FORCEJAVAHOME=
+  export JENV_FORCEJDKHOME=
+
+  local home
+  if ! home=$(jenv javahome 2>/dev/null)
+  then
+    return
+  fi
+
+  export JAVA_HOME=$home
   export JENV_FORCEJAVAHOME=true
 
   if [ -e "$JAVA_HOME/bin/javac" ]
@@ -10,11 +23,10 @@
     export JDK_HOME="$JAVA_HOME"
     export JENV_FORCEJDKHOME=true
   fi
-   }
+}
 
 if ! [[ "$PROMPT_COMMAND" =~ _jenv_export_hook ]]; then
-    PROMPT_COMMAND="_jenv_export_hook;$PROMPT_COMMAND";
+  PROMPT_COMMAND="_jenv_export_hook;$PROMPT_COMMAND";
 fi
-
 
 _jenv_export_hook

--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
@@ -3,7 +3,16 @@ function __jenv_export_hook --on-event fish_prompt
   if not type -q jenv
     return
   end
-  set -gx JAVA_HOME (jenv javahome)
+
+  set -gx JENV_FORCEJAVAHOME ""
+  set -gx JENV_FORCEJDKHOME ""
+
+  set -l home ""
+  if ! set home (jenv javahome 2>/dev/null)
+    return
+  end
+
+  set -gx JAVA_HOME $home
   set -gx JENV_FORCEJAVAHOME true
 
   if test -e "$JAVA_HOME/bin/javac"

--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
@@ -1,7 +1,20 @@
 #export
 
- _jenv_export_hook() {
-  export JAVA_HOME=$(jenv javahome)
+_jenv_export_hook() {
+  if ! type -w jenv &>/dev/null
+  then
+    return
+  fi
+  export JENV_FORCEJAVAHOME=
+  export JENV_FORCEJDKHOME=
+
+  local home
+  if ! home=$(jenv javahome 2>/dev/null)
+  then
+    return
+  fi
+
+  export JAVA_HOME=$home
   export JENV_FORCEJAVAHOME=true
 
   if [ -e "$JAVA_HOME/bin/javac" ]
@@ -9,14 +22,14 @@
     export JDK_HOME="$JAVA_HOME"
     export JENV_FORCEJDKHOME=true
   fi
- }
+}
 
 #echo "configure export plugin for ZSH"
 function install_hook {
   emulate -LR zsh
   typeset -ag precmd_functions
   if [[ -z $precmd_functions[(r)_jenv_export_hook] ]]; then
-        precmd_functions+=_jenv_export_hook;
+    precmd_functions+=_jenv_export_hook;
   fi
 }
 install_hook

--- a/libexec/jenv
+++ b/libexec/jenv
@@ -68,7 +68,6 @@ shopt -s nullglob
 
 
 bin_path="$(abs_dirname "$0")"    
-                  
 if ! samedir "${JENV_ROOT}" "$bin_path/../"  ; then
    JENV_INSTALL_DIR=$(resolvepath "$bin_path/../")
 else

--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -119,7 +119,7 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
         esac
     fi;
 
-    if [ $JAVA_PROVIDER=="sap" ]; then
+    if [ $JAVA_PROVIDER == "sap" ]; then
         JAVA_PLATFORM="64"
     else
         if ${JENV_JAVAPATH}/bin/java -version 2>&1 | grep -q "64-Bit"; then

--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -45,8 +45,7 @@ exportVariable(){
 #  exec jenv shims --short
 #fi
 
-
-if [[ ! -z "$JAVA_HOME" ]] ; then
+if [[ -n "$JAVA_HOME" ]] ; then
   if [[ -z "$JENV_FORCEJAVAHOME" ]] ; then
     cwarn "JAVA_HOME variable already set, scripts that use it directly could not use java version set by jenv"
   else

--- a/libexec/jenv-exec
+++ b/libexec/jenv-exec
@@ -26,30 +26,26 @@ if [ "$1" = "--complete" ]; then
   exec jenv shims --short
 fi
 
-export JENV_VERSION="$(jenv-version-name)"
 JENV_COMMAND="$1"
-
-export JENV_OPTIONS="$(jenv-options)"
-
-if [ "$JENV_VERSION" != "system" ]; then
-  export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"
-fi
 
 if [ -z "$JENV_COMMAND" ]; then
   jenv-help --usage exec >&2
   exit 1
 fi
 
+export JENV_VERSION="$(jenv-version-name)"
+
+export JENV_OPTIONS="$(jenv-options)"
+
+export JAVA_HOME=$(jenv-javahome)
+
 JENV_COMMAND_PATH="$(jenv-which "$JENV_COMMAND")"
 JENV_BIN_PATH="${JENV_COMMAND_PATH%/*}"
+export PATH="${JENV_BIN_PATH}:${PATH}"
 
 for script in $(jenv-hooks exec); do
-
-source "$script"
+  source "$script"
 done
 
 shift 1
-if [ "$JENV_VERSION" != "system" ]; then
-  export PATH="${JENV_BIN_PATH}:${PATH}"
-fi
 exec -a "$JENV_COMMAND" "$JENV_COMMAND_PATH" $JENV_OPTIONS "$@"

--- a/libexec/jenv-info
+++ b/libexec/jenv-info
@@ -17,20 +17,21 @@ exportVariable(){
 
 # Provide jenv completions
 if [ "$1" = "--complete" ]; then
-  exec jenv shims --short
+  exec jenv-shims --short
 fi
 
-export JENV_VERSION="$(jenv-version-name)"
+export JENV_VERSION
+JENV_VERSION="$(jenv-version-name 2>/dev/null)" || :
 
 export JENV_OPTIONS="$(jenv-options)"
 
 JENV_COMMAND="$1"
 
-if [ "$JENV_VERSION" != "system" ]; then
-  export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"
-fi
 
-JENV_COMMAND_PATH="$(jenv-which "$JENV_COMMAND")"
+if ! JENV_COMMAND_PATH="$(jenv-which "$JENV_COMMAND")" ; then
+  echo "Unable to find command $JENV_COMMAND for version $JENV_VERSION" >&2
+  exit 1
+fi
 JENV_BIN_PATH="${JENV_COMMAND_PATH%/*}"
 
 for script in $(jenv-hooks exec); do
@@ -43,7 +44,7 @@ if [ "$JENV_VERSION" != "system" ]; then
 fi
 echo "Jenv will exec : $JENV_COMMAND_PATH $JENV_OPTIONS $@"
 echo "Exported variables :"
-echo "  JAVA_HOME=$JAVA_HOME"
+echo "  JAVA_HOME=$(jenv javahome)"
 while IFS=':' read -ra ADDR; do
       for i in "${ADDR[@]}"; do
       	  if [ -n "$i" ]; then

--- a/libexec/jenv-javahome
+++ b/libexec/jenv-javahome
@@ -7,24 +7,70 @@
 set -e
 [ -n "$JENV_DEBUG" ] && set -x
 
-exportVariable(){
-   exportedValues="$exportedValues:$1"
-   export "$1"="$2"
+resolve_path() {
+  local path="$1"
+  realpath "$path" 2>/dev/null \
+    || readlink -f "$path" 2>/dev/null \
+    || greadlink -f "$path" 2>/dev/null \
+    || { [ -d "$path" ] && (cd -P "$path" && pwd) } \
+    || (
+        local resolver
+        resolver=$(type -p greadlink 2>/dev/null || type -p readlink 2>/dev/null) || :
+        local name
+        while [ -n "$path" ]; do
+          cd -P "${path%/*}"
+          name="${path##*/}"
+          if [ -n "$resolver" ]
+          then
+            path="$("$resolver" "$name" || true)"
+          else
+            path=""
+          fi
+        done
+
+        echo "$(pwd)/$name"
+       )
 }
 
-# Provide jenv completions
-if [ "$1" = "--complete" ]; then
-  exec jenv shims --short
+version=$JENV_VERSION
+[ -z "$version" ] && version="$(jenv-version-name)"
+
+home=""
+if [ "$version" = "system" ]; then
+  if sys_java=$(type -ap java \
+    | awk '$1 !~ "'"${JENV_ROOT}/shims"'" { print $1; exit }'); then
+
+    case "$sys_java" in
+      /bin/java | /usr/bin/java | /usr/local/bin/java | /sbin/java | /usr/sbin/java | /usr/local/sbin/java)
+        sys_java="$(resolve_path "$sys_java" 2>/dev/null)"
+        case "$sys_java" in
+          /bin/java | /usr/bin/java | /usr/local/bin/java | /sbin/java | /usr/sbin/java | /usr/local/sbin/java)
+            sys_java=""
+            ;;
+          *)
+            ;;
+        esac
+        ;;
+      *)
+        ;;
+    esac
+  fi
+
+  if [ -z "$sys_java" ] && [ -f "/usr/libexec/java_home" ] && [ -x "/usr/libexec/java_home" ]; then
+    sys_java="$(/usr/libexec/java_home 2>/dev/null)" || true
+  fi
+
+  if [ -z "$sys_java" ] && type -t update-alternatives >/dev/null; then
+    sys_java=$(update-alternatives --query java 2>/dev/null | sed -n '/^Best:/{s/Best: *//;s/\/bin\/java//;p;}')
+  fi
+
+  if [ -n "$sys_java" ]; then
+    home=$(dirname "$(dirname "$sys_java")")
+  else
+    home=$JAVA_HOME
+  fi
+else
+  home="$JENV_ROOT/versions/$version"
 fi
 
-export JENV_VERSION="$(jenv-version-name)"
-
-export JENV_OPTIONS="$(jenv-options)"
-
-if [ "$JENV_VERSION" == "system" ]; then
-  echo "Using system JDK, no JAVA_HOME set!"
-  exit 1
-fi
-
-export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"
-echo "$JAVA_HOME"
+echo "$home"

--- a/libexec/jenv-rehash
+++ b/libexec/jenv-rehash
@@ -31,41 +31,6 @@ remove_prototype_shim() {
   rm -f "$PROTOTYPE_SHIM_PATH"
 }                               
 
-remove_from_path() {
-  local path_to_remove="$(expand_path "$1")"
-  local result=""
-
-  if [ -z "$path_to_remove" ]; then
-    echo "${PATH}"
-    return
-  fi
-
-  local paths
-  IFS=: paths=($PATH)
-
-  for path in "${paths[@]}"; do
-    path="$(expand_path "$path" || true)"
-    if [ -n "$path" ] && [ "$path" != "$path_to_remove" ]; then
-      result="${result}${path}:"
-    fi
-  done
-
-  echo "${result%:}"
-}
-
-expand_path() {
-  if [ ! -d "$1" ]; then
-    return 1
-  fi
-
-  local cwd="$(pwd)"
-  cd "$1"
-  pwd
-  cd "$cwd"
-}
-                                    
-
-
 # The prototype shim file is a script that re-execs itself, passing
 # its filename and any arguments to `jenv exec`. This file is
 # hard-linked for every executable and then removed. The linking

--- a/libexec/jenv-version-name
+++ b/libexec/jenv-version-name
@@ -26,6 +26,7 @@ elif version_exists "${JENV_VERSION#java-}"; then
   } >&2
   echo "${JENV_VERSION#java-}"
 else
+  echo $JENV_VERSION
   echo "jenv: version \`$JENV_VERSION' is not installed" >&2
   exit 1
 fi

--- a/libexec/jenv-which
+++ b/libexec/jenv-which
@@ -15,39 +15,6 @@ if [ "$1" = "--complete" ]; then
   exec jenv shims --short
 fi
 
-expand_path() {
-  if [ ! -d "$1" ]; then
-    return 1
-  fi
-
-  local cwd="$(pwd)"
-  cd "$1"
-  pwd
-  cd "$cwd"
-}
-
-remove_from_path() {
-  local path_to_remove="$(expand_path "$1")"
-  local result=""
-
-  if [ -z "$path_to_remove" ]; then
-    echo "${PATH}"
-    return
-  fi
-
-  local paths
-  IFS=: paths=($PATH)
-
-  for path in "${paths[@]}"; do
-    path="$(expand_path "$path" || true)"
-    if [ -n "$path" ] && [ "$path" != "$path_to_remove" ]; then
-      result="${result}${path}:"
-    fi
-  done
-
-  echo "${result%:}"
-}
-
 JENV_VERSION="$(jenv-version-name)"
 JENV_COMMAND="$1"
 
@@ -57,15 +24,14 @@ if [ -z "$JENV_COMMAND" ]; then
 fi
 
 if [ "$JENV_VERSION" = "system" ]; then
-  PATH="$(remove_from_path "${JENV_ROOT}/shims")"
-  JENV_COMMAND_PATH="$(command -v "$JENV_COMMAND" || true)"
+  JENV_COMMAND_PATH=$(type -ap "$JENV_COMMAND" \
+    | awk '$1 !~ "'"${JENV_ROOT}/shims"'" { print $1; exit }') || true
 else
   JENV_COMMAND_PATH="${JENV_ROOT}/versions/${JENV_VERSION}/bin/${JENV_COMMAND}"
   if ! [ -x "$JENV_COMMAND_PATH" ]; then
-   	PATH="$(remove_from_path "${JENV_ROOT}/shims")"
-	JENV_COMMAND_PATH="$(command -v "$JENV_COMMAND" || true)"   
+    JENV_COMMAND_PATH=$(type -ap "$JENV_COMMAND" \
+      | awk '$1 !~ "'"${JENV_ROOT}/shims"'" { print $1; exit }') || true
   fi
-  
 fi
 
 for script in $(jenv-hooks which); do


### PR DESCRIPTION
Use java from the path with jenv shims and locations removed. Set JAVA_HOME to be the linked java home from above, if it exists, otherwise search for OS utility programs which can pinpoint the javahome like libexec java_home or alternatives.
Fallback to whatever JAVA_HOME is currently set to if it can't otherwise be resolved.